### PR TITLE
fix(version): CNI plugins updated to `1.6.2` release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # See available releases: https://github.com/containernetworking/plugins/releases
-cni_plugins_version: '1.6.1'
+cni_plugins_version: '1.6.2'
 cni_plugins_archive_name: 'cni-plugins-linux-{{ __cni_plugins_architecture }}-v{{ cni_plugins_version }}.tgz'
 cni_plugins_download_url: 'https://github.com/containernetworking/plugins/releases/download/v{{ cni_plugins_version }}'
 cni_plugins_checksum_url: '{{ cni_plugins_download_url }}/{{ cni_plugins_archive_name }}.sha256'

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -9,7 +9,7 @@ argument_specs:
       cni_plugins_version:
         type: 'str'
         description: 'The version of CNI plugins to install.'
-        default: '1.6.1'
+        default: '1.6.2'
       cni_plugins_archive_name:
         type: 'str'
         description: 'The CNI plugins archive name.'


### PR DESCRIPTION
The upstream [CNI plugins](https://github.com/containernetworking/plugins/releases) released new software version - **1.6.2**!

This automated PR updates code to bring new version into repository.